### PR TITLE
Updating k8s `apiVersion` to current version

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ex-cluster
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: ex-cluster  
   template:
     metadata:
       labels:


### PR DESCRIPTION
- Updating k8s `apiVersion` to current version 
- Adding Selectors as required by the k8s API
Related https://github.com/dollarshaveclub/ex_cluster/issues/6